### PR TITLE
Bash script to `hledger print` back to file [1h]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+Example for use of [hledger](https://hledger.org/).
+
+See [Blog post](https://www.gizra.com/content/plain-text-accounting-hledger/)
+
+## Install
+
+* `brew` from [here](https://hledger.org/download.html#binary-packages) 
+* Or `stack` from [here](https://hledger.org/download.html#building-from-source)
+* Or with Docker `docker pull dastapov/hledger`
+
+## Ledger-UI
+
+`hledger-ui -f hledger.journal   --watch -b='last week' -2` and then: right, F (shift + f) to see future events
+
+Or with Docker
+
+`docker container run --rm -it --volume="$PWD:/data" dastapov/hledger hledger-ui -f /data/hledger.journal --watch -b='last week' -2`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ See [Blog post](https://www.gizra.com/content/plain-text-accounting-hledger/)
 
 ## Install
 
-* `brew` from [here](https://hledger.org/download.html#binary-packages) 
+* `brew` from [here](https://hledger.org/download.html#binary-packages)
 * Or `stack` from [here](https://hledger.org/download.html#building-from-source)
 * Or with Docker `docker pull dastapov/hledger`
 
@@ -15,3 +15,17 @@ See [Blog post](https://www.gizra.com/content/plain-text-accounting-hledger/)
 Or with Docker
 
 `docker container run --rm -it --volume="$PWD:/data" dastapov/hledger hledger-ui -f /data/hledger.journal --watch -b='last week' -2`
+
+## More examples
+
+Get all Israeli credit card expenses by month
+
+`hledger -f hledger.journal reg -H expenses:israel:cc -3 -M`
+
+## Reorder dates
+
+We can use `hledger -f hledger.journal check-dates` to confirm all transactions
+are ordered by date.
+
+If they are not, we can use `./reorder-journal.sh hledger.journal` to have it
+re-ordered.

--- a/hledger.journal
+++ b/hledger.journal
@@ -44,9 +44,10 @@ commodity ILS:BOJ
 2019/01/01 set initial assets balance, USD:BOJ
     (assets:banks-ancillary:israel:boi:usd)     USD:BOJ50
 
-;;
+
 ;; 2019 Cash flow starts here.
 ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 2019/02/05 Israel Salaries, Janurary 2019
     expenses:israel:salary     ILS2000

--- a/hledger.journal
+++ b/hledger.journal
@@ -48,36 +48,46 @@ commodity ILS:BOJ
 ;; 2019 Cash flow starts here.
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+2019/01/01 set initial assets balance, ILS:BOI
+    (assets:banks:israel:boi:ils)    ILS 10,000.00
+
+2019/01/01 set initial assets balance, USD:BOI
+    (assets:banks:israel:boi:usd)    USD:BOI 500.00
+
+2019/01/01 set initial assets balance, BOA
+    (assets:banks:us:boa)         USD1000
+
+2019/01/01 set initial assets balance, ILS:BOJ
+    (assets:banks-ancillary:israel:boj:ils)    ILS:BOJ 300.00
+
+2019/01/01 set initial assets balance, USD:BOJ
+    (assets:banks-ancillary:israel:boi:usd)       USD:BOJ50
 
 2019/02/05 Israel Salaries, Janurary 2019
-    expenses:israel:salary     ILS2000
+    expenses:israel:salary         ILS 2,000.00
     assets:banks:israel:boi:ils
 
 2019/02/05 US Salaries, Janurary 2019
-    expenses:us:salary     USD700
+    expenses:us:salary           USD700
     assets:banks:us:boa
 
-; We transfer USD, but we mark it with a different commodity in Israel.
 2019/02/08 Transfer from US to Israel
-    assets:banks:israel:boi:usd  USD:BOI200
-    assets:banks:us:boa     USD-200
+    assets:banks:israel:boi:usd    USD:BOI 200.00
+    assets:banks:us:boa                   USD-200
 
-; Here we tell hledger the conversion rate we got from USD to ILS.
 2019/02/08 Convert the money that was transfered from USD to ILS
-    assets:banks:israel:boi:ils        ILS340 @@ USD:BOI100
+    assets:banks:israel:boi:ils    ILS 340.00 @@ USD:BOI100
     assets:banks:israel:boi:usd
 
-; `cc:1234` means in this context Credit card ending with `1234`.
 2019/02/15 Credit card ILS, Janurary 2019
-    liabilities:israel:cc:1234:ils                ILS600
+    liabilities:israel:cc:1234:ils      ILS 600.00
     assets:banks:israel:boi:ils
 
 2019/02/15 Credit card USD, Janurary 2019
-    liabilities:israel:cc:1234:usd                USD:BOI150
+    liabilities:israel:cc:1234:usd    USD:BOI 150.00
     assets:banks:israel:boi:usd
 
-
-; Some date in the future
 2025/02/05 US Salaries, Janurary 2025
-    expenses:us:salary     USD700
+    expenses:us:salary           USD700
     assets:banks:us:boa
+

--- a/hledger.journal
+++ b/hledger.journal
@@ -33,6 +33,7 @@ commodity ILS:BOJ
 ;; Cash flow starts here.
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 2019/01/01 set initial assets balance, ILS:BOI
     (assets:banks:israel:boi:ils)    ILS 10,000.00
 

--- a/hledger.journal
+++ b/hledger.journal
@@ -29,25 +29,25 @@ commodity ILS:BOJ
 ; what's the exact state of the main banks.
 ; For this reason we register them as `assets:banks-ancillary`.
 
-2019/01/01 set initial assets balance, ILS:BOI
-    (assets:banks:israel:boi:ils)               ILS10,000.00
 
-2019/01/01 set initial assets balance, USD:BOI
-    (assets:banks:israel:boi:usd)               USD:BOI500
-
-2019/01/01 set initial assets balance, BOA
-    (assets:banks:us:boa)                       USD1000
-
-2019/01/01 set initial assets balance, ILS:BOJ
-    (assets:banks-ancillary:israel:boj:ils)     ILS:BOJ300
-
-2019/01/01 set initial assets balance, USD:BOJ
-    (assets:banks-ancillary:israel:boi:usd)     USD:BOJ50
-
-
-;; 2019 Cash flow starts here.
+;; Cash flow starts here.
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+2019/01/01 set initial assets balance, ILS:BOI
+    (assets:banks:israel:boi:ils)    ILS 10,000.00
+
+2019/01/01 set initial assets balance, USD:BOI
+    (assets:banks:israel:boi:usd)    USD:BOI 500.00
+
+2019/01/01 set initial assets balance, BOA
+    (assets:banks:us:boa)         USD1000
+
+2019/01/01 set initial assets balance, ILS:BOJ
+    (assets:banks-ancillary:israel:boj:ils)    ILS:BOJ 300.00
+
+2019/01/01 set initial assets balance, USD:BOJ
+    (assets:banks-ancillary:israel:boi:usd)       USD:BOJ50
+
 2019/01/01 set initial assets balance, ILS:BOI
     (assets:banks:israel:boi:ils)    ILS 10,000.00
 

--- a/hledger.journal
+++ b/hledger.journal
@@ -13,6 +13,9 @@ P 2019-01-01 ILS:BOJ ILS1
 commodity ILS
   format ILS 9,999,999.00
 
+commodity USD
+  format USD 9,999,999.00
+
 commodity USD:BOI
   format USD:BOI 9,999,999.00
 
@@ -91,4 +94,3 @@ commodity ILS:BOJ
 2025/02/05 US Salaries, Janurary 2025
     expenses:us:salary           USD700
     assets:banks:us:boa
-

--- a/reorder-journal.sh
+++ b/reorder-journal.sh
@@ -7,6 +7,11 @@ fi
 
 LEDGER_FILE="$1"
 
+if [[ -z "$LEDGER_FILE" ]]; then
+  echo "Please specify the ledger file in the first argument. ./reorder-journal.sh myledger.journal"
+  exit 1
+fi
+
 TMPFILE_SORTED=$(mktemp /tmp/hledger.XXXXXX)
 TMPFILE_SKELETON=$(mktemp /tmp/hledger.XXXXXX)
 

--- a/reorder-journal.sh
+++ b/reorder-journal.sh
@@ -8,7 +8,7 @@ fi
 LEDGER_FILE="$1"
 
 if [[ -z "$LEDGER_FILE" ]]; then
-  echo "Please specify the ledger file in the first argument. ./reorder-journal.sh myledger.journal"
+  echo "Please specify the ledger file in the first argument. ./reorder-journal.sh hledger.journal"
   exit 1
 fi
 

--- a/reorder-journal.sh
+++ b/reorder-journal.sh
@@ -7,9 +7,13 @@ fi
 
 LEDGER_FILE="$1"
 
-TMPFILE=$(mktemp /tmp/hledger.XXXXXX)
+TMPFILE_SORTED=$(mktemp /tmp/hledger.XXXXXX)
+TMPFILE_SKELETON=$(mktemp /tmp/hledger.XXXXXX)
 
-hledger print -f "$LEDGER_FILE" >> "$TMPFILE"
+hledger print -f "$LEDGER_FILE" > "$TMPFILE_SORTED"
 
+sed '/;;;;;;;;;;;;;;;;;;;;;;;;;;;;;/q' "$LEDGER_FILE" > "$TMPFILE_SKELETON"
 
-rm "$TMPFILE"
+cat "$TMPFILE_SKELETON" "$TMPFILE_SORTED" > "$LEDGER_FILE"
+
+rm "$TMPFILE_SORTED" "$TMPFILE_SKELETON"

--- a/reorder-journal.sh
+++ b/reorder-journal.sh
@@ -25,7 +25,7 @@ fi
 
 if [[ 1 -ne $(fgrep "$SEPARATOR" "$LEDGER_FILE" | wc -l) ]];
 then
-  echo "The ledger file might be corrupted or incompatible with this script."
+  echo "The expected separator [show-separator] is missing or appears more than once."
   exit 1
 fi
 

--- a/reorder-journal.sh
+++ b/reorder-journal.sh
@@ -19,7 +19,7 @@ TMPFILE_SKELETON=$(mktemp /tmp/hledger.XXXXXX)
 if ! hledger print -f "$LEDGER_FILE" > "$TMPFILE_SORTED";
 then
   rm "$TMPFILE_SORTED" "$TMPFILE_SKELETON"
-  echo "The ledger file might be corrupted or incompatible with the current version of hledger."
+  echo "The ledger file is not valid. Run `hledger print` to see the cause of the error."
   exit 1
 fi
 

--- a/reorder-journal.sh
+++ b/reorder-journal.sh
@@ -18,6 +18,7 @@ TMPFILE_SKELETON=$(mktemp /tmp/hledger.XXXXXX)
 hledger print -f "$LEDGER_FILE" > "$TMPFILE_SORTED"
 
 sed '/;;;;;;;;;;;;;;;;;;;;;;;;;;;;;/q' "$LEDGER_FILE" > "$TMPFILE_SKELETON"
+echo "" >> "$TMPFILE_SKELETON"
 
 cat "$TMPFILE_SKELETON" "$TMPFILE_SORTED" > "$LEDGER_FILE"
 

--- a/reorder-journal.sh
+++ b/reorder-journal.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if ! [ -x "$(command -v hledger)" ]; then
+  echo 'Error: hledger is not installed.' >&2
+  exit 1
+fi
+
+LEDGER_FILE="$1"
+
+TMPFILE=$(mktemp /tmp/hledger.XXXXXX)
+
+hledger print -f "$LEDGER_FILE" >> "$TMPFILE"
+
+
+rm "$TMPFILE"

--- a/reorder-journal.sh
+++ b/reorder-journal.sh
@@ -19,13 +19,13 @@ TMPFILE_SKELETON=$(mktemp /tmp/hledger.XXXXXX)
 if ! hledger print -f "$LEDGER_FILE" > "$TMPFILE_SORTED";
 then
   rm "$TMPFILE_SORTED" "$TMPFILE_SKELETON"
-  echo "The ledger file is not valid. Run `hledger print` to see the cause of the error."
+  echo "The ledger file is not valid. Run 'hledger print' to see the cause of the error."
   exit 1
 fi
 
 if [[ 1 -ne $(fgrep "$SEPARATOR" "$LEDGER_FILE" | wc -l) ]];
 then
-  echo "The expected separator [show-separator] is missing or appears more than once."
+  echo "The expected separator '$SEPARATOR' is missing or appears more than once."
   exit 1
 fi
 


### PR DESCRIPTION
I'd like my ledger to be sorted by date, but I want to avoid manually having to move transactions. Since `hledger print` sorts by date, I would have liked to have a script to rewrite my ledger file with the print output - but keeping my directives on the beginning of the file intact.

So the script could for example look for those `;;;;;;;;;;;;;;;;;;;;;;;;;;;;;` signs, and replace the content below with the output of `hledger print`

@AronNovak, this one is probably a better task for you :)